### PR TITLE
Avoided switching on and off shift register pin

### DIFF
--- a/esphome/components/dtr0xx_io/dtr0xx_io.cpp
+++ b/esphome/components/dtr0xx_io/dtr0xx_io.cpp
@@ -53,8 +53,8 @@ void dtr0xx_ioComponent::digital_write_(uint16_t pin, bool value)
 
 void dtr0xx_ioComponent::read_gpio_() {
 
-  this->dingtian_pl_pin_->digital_write(true);
-  delayMicroseconds(10);
+  //this->dingtian_pl_pin_->digital_write(true);
+  //delayMicroseconds(10);
 
   if (this->dingtian_rck_pin_ != nullptr)
     this->dingtian_rck_pin_->digital_write(false);
@@ -69,10 +69,11 @@ void dtr0xx_ioComponent::read_gpio_() {
       delayMicroseconds(10);
     }
   }
-  this->dingtian_pl_pin_->digital_write(false);
+  //this->dingtian_pl_pin_->digital_write(false);
   //if (this->dingtian_rck_pin_ != nullptr)
     this->dingtian_rck_pin_->digital_write(true);
-    this->dingtian_rck_pin_->digital_write(false);
+    delayMicroseconds(10);
+      this->dingtian_rck_pin_->digital_write(false);
 }
 
 float dtr0xx_ioComponent::get_setup_priority() const { return setup_priority::IO; }


### PR DESCRIPTION
Found out that the buzzing problem on the 16ch board was due to the frequent switching on and off of the shift register pin. 
Avoiding that practice makes the board completely silent and hopefully saves the relays from early death. On the 8ch board should be the same, but since the frequency is way higher the problem might be not easy to spot.